### PR TITLE
Fix readme header rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-#PongECS
+# PongECS
 
-##Dependencies
+## Dependencies
 
-###[HaxeFlixel](https://github.com/HaxeFlixel/flixel)
+### [HaxeFlixel](https://github.com/HaxeFlixel/flixel)
 Install the `dev` branch
 ```
 haxelib git flixel https://github.com/HaxeFlixel/flixel
 ```
-###[Edge](https://github.com/fponticelli/edge)
+### [Edge](https://github.com/fponticelli/edge)
 Install my fork of the Edge ECS engine by [@fponticelli](https://github.com/fponticelli)
 ```
 haxelib git edge https://github.com/DleanJeans/edge
 ```
 
-##Classes
+## Classes
 
-###[`G`](https://github.com/DleanJeans/PongECS/blob/master/source/G.hx)
+### [`G`](https://github.com/DleanJeans/PongECS/blob/master/source/G.hx)
 The global class for reference to the `FlxState`, `Game` and `UI`.
 
-###[`Game`](https://github.com/DleanJeans/PongECS/blob/master/source/Game.hx)
+### [`Game`](https://github.com/DleanJeans/PongECS/blob/master/source/Game.hx)
 Contains and setups the Edge engine, FlxSpriteGroups, managers, systems, phases and signals.
 
-###[`UI`](https://github.com/DleanJeans/PongECS/blob/master/source/UI.hx)
+### [`UI`](https://github.com/DleanJeans/PongECS/blob/master/source/UI.hx)
 Uses MVC, MVP or something like that, kinda :P.  
 Contains the all the UI components of the game.


### PR DESCRIPTION
GitHub changed their markdown rendering somewhat recently, making the space after `#` in headers mandatory.